### PR TITLE
feat(esw): avoid duplicated building when we set duplicated path

### DIFF
--- a/packages/esw/src/build.ts
+++ b/packages/esw/src/build.ts
@@ -14,7 +14,8 @@ import {
   combineLatest,
   pipe,
   asapScheduler,
-  scheduled
+  scheduled,
+  distinctUntilChanged
 } from 'rxjs'
 import { PackageJson } from 'type-fest'
 import isNil from 'lodash/isNil'
@@ -96,6 +97,9 @@ export default function runBuild(
 
       return isMatchedField && (!isEsModuleEntry || isAvailableEsModuleEntry)
     }),
+    distinctUntilChanged(
+      ([, prevOutPath], [, currentOutPath]) => prevOutPath === currentOutPath
+    ),
     map(([, outPath, field, alternativeFmt]) => ({
       outPath,
       field,

--- a/packages/esw/test/build.spec.ts
+++ b/packages/esw/test/build.spec.ts
@@ -1,4 +1,4 @@
-import { BuildOptions } from 'esbuild'
+import * as esbuild from 'esbuild'
 import identity from 'lodash/identity'
 import pick from 'lodash/pick'
 import { build } from '../src'
@@ -12,7 +12,7 @@ import {
 
 async function runFixtureCase(
   fixtureName: string,
-  options: BuildOptions,
+  options: esbuild.BuildOptions,
   singleEntry = 'index.ts'
 ) {
   const results = await build({
@@ -186,6 +186,29 @@ describe('build api', () => {
     expect(hasWarnings(buildResults)).toBeFalsy()
     expect(buildResults).toMatchSnapshot(getTestName())
   })
+
+  /**
+   * @see https://stackoverflow.com/a/57764111
+   * @see https://stackoverflow.com/a/53166827
+   * @see https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
+   */
+  // TODO: Needs to mock esbuild dependency
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // it('should emit building only once when we have duplicated output path', async () => {
+  //   const mockBuild = jest.fn(() => Promise.resolve())
+  //   // use jest.doMock to avoid jest to hoist mock to the beginning of the file
+  //   // @see https://stackoverflow.com/a/53166827
+  //   // @see https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options
+  //   jest.doMock('esbuild', () => ({
+  //     build: mockBuild
+  //   }))
+  //   await build({
+  //     absWorkingDir: resolveFixture('duplicated-entry-points'),
+  //     logLevel: 'debug'
+  //   })
+  //   expect(mockBuild).toBeCalledTimes(1)
+  //   jest.resetModules()
+  // })
 
   it('should emit a error when splitting: true and format !== esm', async () => {
     await expect(

--- a/packages/esw/test/fixture/duplicated-entry-points/index.ts
+++ b/packages/esw/test/fixture/duplicated-entry-points/index.ts
@@ -1,0 +1,6 @@
+import { fib } from './src/fib'
+
+export default function (n: number) {
+  if (n < 2) return n
+  return fib(n)
+}

--- a/packages/esw/test/fixture/duplicated-entry-points/package.json
+++ b/packages/esw/test/fixture/duplicated-entry-points/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "duplicated-entry-points",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "module": "dist/index.js"
+}

--- a/packages/esw/test/fixture/duplicated-entry-points/src/fib.ts
+++ b/packages/esw/test/fixture/duplicated-entry-points/src/fib.ts
@@ -1,0 +1,10 @@
+export function fib(n: number) {
+  let a = 0,
+    b = 1
+  while (n--) {
+    const next = a + b
+    a = b
+    b = next
+  }
+  return a
+}


### PR DESCRIPTION
fix #18 