### PR TITLE
fix(esw): resume inferBuildOption Observable

### DIFF
--- a/packages/esw/package.json
+++ b/packages/esw/package.json
@@ -45,7 +45,6 @@
     "@lbwa/tsconfig": "^1.0.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/lodash": "^4.14.171",
-    "chokidar": "^3.5.2",
     "cross-spawn": "^7.0.3",
     "typescript": "^4.5.4"
   },
@@ -53,6 +52,7 @@
   "dependencies": {
     "@eswjs/common": "^0.5.1",
     "arg": "^5.0.0",
+    "chokidar": "^3.5.2",
     "esbuild": "^0.14.10",
     "lodash": "^4.17.21",
     "rxjs": "^7.3.0",

--- a/packages/esw/package.json
+++ b/packages/esw/package.json
@@ -53,9 +53,9 @@
     "@eswjs/common": "^0.5.1",
     "arg": "^5.0.0",
     "chokidar": "^3.5.2",
-    "esbuild": "^0.14.10",
+    "esbuild": "~0.14.10",
     "lodash": "^4.17.21",
-    "rxjs": "^7.3.0",
+    "rxjs": "~7.4.0",
     "type-fest": "^1.2.2"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,7 +2879,7 @@ esbuild-windows-arm64@0.14.10:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.10.tgz#50ab9a83f6ccf71c272e58489ecc4d7375075f32"
   integrity sha512-OJOyxDtabvcUYTc+O4dR0JMzLBz6G9+gXIHA7Oc5d5Fv1xiYa0nUeo8+W5s2e6ZkPRdIwOseYoL70rZz80S5BA==
 
-esbuild@^0.14.10:
+esbuild@^0.14.10, esbuild@~0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.10.tgz#10268d2b576b25ed6f8554553413988628a7767b"
   integrity sha512-ibZb+NwFqBwHHJlpnFMtg4aNmVK+LUtYMFC9CuKs6lDCBEvCHpqCFZFEirpqt1jOugwKGx8gALNGvX56lQyfew==
@@ -6110,10 +6110,10 @@ rxjs@^6.6.0, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
-  integrity sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==
+rxjs@~7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
   dependencies:
     tslib "~2.1.0"
 


### PR DESCRIPTION
rxjs@7.5.1 would never complete the following observable:

https://github.com/lbwa/esw/blob/90a7ccd4ed26e6dd60832018b47154a0ac2a3cfd/packages/esw/src/build/options.ts#L57-L62

therefore, the following `toArray` would never be completed,

https://github.com/lbwa/esw/blob/a1bda051ea9a8bfa940d0eadb04264dde19c1f27/packages/esw/src/build/node.ts#L48

and it occur run$ observable never be completed.

https://github.com/lbwa/esw/blob/a1bda051ea9a8bfa940d0eadb04264dde19c1f27/packages/esw/src/build/node.ts#L85